### PR TITLE
feat(model): add camunda:InputParameterSupported and camunda:OutputParameterSupported

### DIFF
--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -1,6 +1,6 @@
 {
   "name": "Camunda",
-  "uri": "http://activiti.org/bpmn",
+  "uri": "http://camunda.org/schema/1.0/bpmn",
   "prefix": "camunda",
   "xml": {
     "tagAlias": "lowerCase"

--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -1,6 +1,6 @@
 {
   "name": "Camunda",
-  "uri": "http://camunda.org/schema/1.0/bpmn",
+  "uri": "http://activiti.org/bpmn",
   "prefix": "camunda",
   "xml": {
     "tagAlias": "lowerCase"
@@ -638,6 +638,11 @@
       "properties": [
         {
           "name": "collection",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "elementVariable",
           "isAttr": true,
           "type": "String"
         }

--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -171,6 +171,35 @@
       ]
     },
     {
+      "name": "InputParameterSupported",
+      "isAbstract": true,
+      "extends": [
+        "bpmn:StartEvent",
+        "bpmn:UserTask",
+        "bpmn:ReceiveTask",
+        "bpmn:SendTask",
+        "bpmn:ServiceTask",
+        "bpmn:BusinessRuleTask",
+        "bpmn:ScriptTask",
+        "bpmn:Task",
+        "bpmn:ManualTask"		
+      ]
+    },
+	{
+      "name": "OutputParameterSupported",
+      "isAbstract": true,
+      "extends": [
+        "bpmn:UserTask",
+        "bpmn:ReceiveTask",
+        "bpmn:SendTask",
+        "bpmn:ServiceTask",
+        "bpmn:BusinessRuleTask",
+        "bpmn:ScriptTask",
+        "bpmn:Task",
+        "bpmn:ManualTask"		
+      ]
+    },
+    {
       "name": "ScriptTask",
       "isAbstract": true,
       "extends": [
@@ -609,11 +638,6 @@
       "properties": [
         {
           "name": "collection",
-          "isAttr": true,
-          "type": "String"
-        },
-        {
-          "name": "elementVariable",
           "isAttr": true,
           "type": "String"
         }


### PR DESCRIPTION
1. In the properties panel(bpmn-js-properties-panel), the property boxes for input and output parameters are not available
2. If both were to be made available, two abstract types in camunda.json could be added: InputParameterSupported and OutputParameterSupported
3. These abstract types extend(group) all the bpmn elements that contain the respective parameter
