### PR TITLE
Remove lodash from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,5 @@
     "load-grunt-tasks": "^0.3.0",
     "xsd-schema-validator": "^0.3.0"
   },
-  "dependencies": {
-    "lodash": "^3.0.0"
-  }
+  "dependencies": {}
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -21,3 +21,18 @@ function createModdle() {
 }
 
 module.exports.createModdle = createModdle;
+
+function assign() {
+  if (arguments.length === 0) return;
+  var args = Array.prototype.slice.call(arguments);
+  return args.reduce(function assignNext(result, obj) {
+    if (result === undefined) return obj;
+    if (!obj) return result;
+    Object.keys(obj).forEach(function setKey(key) {
+      result[key] = obj[key];
+    });
+    return result;
+  });
+}
+
+module.exports.assign = assign;

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var assign = require('lodash/object/assign'),
-    isFunction = require('lodash/lang/isFunction');
-
 var Helper = require('../../helper');
 
 
@@ -12,13 +9,13 @@ describe('write', function() {
 
 
   function write(element, options, callback) {
-    if (isFunction(options)) {
+    if (typeof options === 'function') {
       callback = options;
       options = {};
     }
 
     // skip preamble for tests
-    options = assign({ preamble: false }, options);
+    options = Object.assign({ preamble: false }, options);
 
     moddle.toXML(element, options, callback);
   }

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Helper = require('../../helper');
-
+var assign = Helper.assign;
 
 describe('write', function() {
 
@@ -15,7 +15,7 @@ describe('write', function() {
     }
 
     // skip preamble for tests
-    options = Object.assign({ preamble: false }, options);
+    options = assign({ preamble: false }, options);
 
     moddle.toXML(element, options, callback);
   }


### PR DESCRIPTION
I humble request to remove `lodash` from dependencies. Made a "polyfill" in Helpers to support assign.

When installing modules in node you get a lot of lodash versions. Perhaps it is possible to remove this one!?