### PR TITLE
ES6 importing of Camunda Moddle Extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,27 @@
-// this module does not expose any public API (yet!)
+/*
+	Import and using it with ES6:
+	----------------------------
+	import * as BpmnModeler from 'bpmn-js/lib/Modeler';
+	import { CamundaModdleExtension, CamundaModdleExtensionJson } from 'camunda-bpmn-moddle';
+
+
+	Using it:
+	---------
+	const modeler = new BpmnModeler({
+		additionalModules: [
+			CamundaModdleExtension
+		],
+		moddleExtensions: {
+			camunda: CamundaModdleExtensionJson
+		}
+	});
+
+*/
+
+'use strict';
+
+module.exports = {
+  __init__: [ 'CamundaModdleExtension' ],
+  CamundaModdleExtension: [ 'type', require('./lib/extension') ],
+  CamundaModdleExtensionJson: require('./resources/camunda.json')
+};

--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
-  "name": "camunda-bpmn-moddle",
-  "version": "0.11.0",
-  "description": "Camunda moddle extensions for BPMN 2.0",
+  "name": "camunda-bpmn-moddle-es6",
+  "version": "1.0.0",
+  "description": "Camunda moddle extensions for BPMN 2.0 with ES6 import",
   "scripts": {
     "all": "grunt",
     "test": "grunt test"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/camunda/camunda-bpmn-moddle"
+    "url": "https://github.com/laserman83/camunda-bpmn-moddle-es6"
   },
   "keywords": [
     "bpmn",
     "moddle",
     "bpmn20",
     "camunda",
-    "meta-model"
+    "meta-model",
+    "es6"
   ],
   "author": {
-    "name": "Nico Rehwaldt",
-    "url": "https://github.com/nikku"
+    "name": "David Carvalho",
+    "url": "https://github.com/laserman83"
   },
   "contributors": [
     {


### PR DESCRIPTION
I created this fork for importing lib and json file using ES6 importing syntax.
I would like to merge with your main branch so I would be always up to date with the camunda defintions.

When merging, please remove of course, my author information about this branch. I inserted it in case of you don't accept this merge request.

Thank you.

David Carvalho