### PR TITLE
feat(camunda): extend schema with "errorMessage" property

### DIFF
--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -154,6 +154,20 @@
       ]
     },
     {
+      "name": "Error",
+      "isAbstract": true,
+      "extends": [
+        "bpmn:Error"
+      ],
+      "properties": [
+        {
+          "name": "camunda:errorMessage",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "PotentialStarter",
       "superClass": [
         "Element"

--- a/test/fixtures/xml/camunda-errorMessage.part.bpmn
+++ b/test/fixtures/xml/camunda-errorMessage.part.bpmn
@@ -1,0 +1,4 @@
+<bpmn:error 
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
+    xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+    camunda:errorMessage="errorMessage" />

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -191,6 +191,30 @@ describe('read', function() {
     });
 
 
+    describe('camunda:errorMessage', function() {
+
+      it('on Error', function(done) {
+
+        // given
+        var xml = readFile('test/fixtures/xml/camunda-errorMessage.part.bpmn');
+
+        // when
+        moddle.fromXML(xml, 'bpmn:Error', function(err, definition) {
+
+          // then
+          expect(definition).to.jsonEqual({
+            $type: 'bpmn:Error',
+            errorMessage: 'errorMessage'
+          });
+
+          done(err);
+        });
+
+      });
+
+    });
+
+
     it('camunda:script', function(done) {
 
       // given


### PR DESCRIPTION
Relates to camunda/camunda-modeler#1333