### PR TITLE
chore(moddle): rewrite and simplify rules

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -34,28 +34,57 @@ CamundaModdleExtension.prototype.canCopyProperty = function(property, parent) {
 
   // (2) check more complex scenarios
 
-  // connector and field
-  if (isAny(property, [ 'camunda:Connector', 'camunda:Field' ])) {
-
-    // check wether parent is message event definition and is child of intermediate throwing event
-    // or end event
-    if (getParent(parent, 'bpmn:MessageEventDefinition') &&
-      !getParent(parent, 'bpmn:IntermediateThrowEvent') &&
-      !getParent(parent, 'bpmn:EndEvent')) {
-      return false;
-    }
-
+  if (is(property, 'camunda:InputOutput') && !this.canHostInputOutput(parent)) {
+    return false;
   }
 
-  // retry cycle
-  if (is(property, 'camunda:FailedJobRetryTimeCycle')) {
-
-    // check wether parent is event that does NOT have signal or timer event definition
-    if (getParent(parent, 'bpmn:Event') && !canCopyRetryCycle(parent)) {
-      return false;
-    }
-
+  if (isAny(property, [ 'camunda:Connector', 'camunda:Field' ]) && !this.canHostConnector(parent)) {
+    return false;
   }
+
+};
+
+CamundaModdleExtension.prototype.canHostInputOutput = function(parent) {
+
+  // allowed in camunda:Connector
+  var connector = getParent(parent, 'camunda:Connector');
+
+  if (connector) {
+    return true;
+  }
+
+  // special rules inside bpmn:FlowNode
+  var flowNode = getParent(parent, 'bpmn:FlowNode');
+
+  if (!flowNode) {
+    return false;
+  }
+
+  if (isAny(flowNode, [ 'bpmn:StartEvent', 'bpmn:Gateway', 'bpmn:BoundaryEvent' ])) {
+    return false;
+  }
+
+  if (is(flowNode, 'bpmn:SubProcess') && flowNode.get('triggeredByEvent')) {
+    return false;
+  }
+
+  return true;
+};
+
+CamundaModdleExtension.prototype.canHostConnector = function(parent) {
+
+  var serviceTaskLike = getParent(parent, 'camunda:ServiceTaskLike');
+
+  if (is(serviceTaskLike, 'bpmn:MessageEventDefinition')) {
+
+    // only allow on throw and end events
+    return (
+      getParent(parent, 'bpmn:IntermediateThrowEvent') ||
+      getParent(parent, 'bpmn:EndEvent')
+    );
+  }
+
+  return true;
 };
 
 module.exports = CamundaModdleExtension;
@@ -107,26 +136,4 @@ function isAllowedInParent(property, parent) {
 
 function isWildcard(allowedIn) {
   return allowedIn.indexOf(WILDCARD) !== -1;
-}
-
-function canCopyRetryCycle(parent) {
-  var eventDefinition =
-    getParent(parent, 'bpmn:SignalEventDefinition') ||
-    getParent(parent, 'bpmn:TimerEventDefinition');
-
-  if (!eventDefinition) {
-    return false;
-  }
-
-  // allow copying if parent signal event is intermediate throwing
-  if (is(eventDefinition, 'bpmn:SignalEventDefinition')) {
-    return getParent(parent, 'bpmn:IntermediateThrowEvent');
-  }
-
-  // allow copying if parent timer event is catching
-  if (is(eventDefinition, 'bpmn:TimerEventDefinition')) {
-    return getParent(parent, 'bpmn:CatchEvent');
-  }
-
-  return false;
 }

--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -567,28 +567,8 @@
       ],
       "meta": {
         "allowedIn": [
-          "bpmn:Task",
-          "bpmn:UserTask",
-          "bpmn:ServiceTask",
-          "bpmn:SendTask",
-          "bpmn:BusinessRuleTask",
-          "bpmn:ReceiveTask",
-          "bpmn:ScriptTask",
-          "bpmn:ManualTask",
-          "bpmn:GlobalUserTask",
-          "bpmn:GlobalScriptTask",
-          "bpmn:GlobalBusinessRuleTask",
-          "bpmn:GlobalTask",
-          "bpmn:GlobalManualTask",
-          "bpmn:SubProcess",
-          "bpmn:Transaction",
-          "bpmn:IntermediateCatchEvent",
-          "bpmn:IntermediateThrowEvent",
-          "bpmn:EndEvent",
-          "bpmn:ThrowEvent",
-          "bpmn:CatchEvent",
-          "bpmn:ImplicitThrowEvent",
-          "bpmn:CallActivity"
+          "bpmn:FlowNode",
+          "camunda:Connector"
         ]
       },
       "properties": [
@@ -782,18 +762,8 @@
       "superClass": [ "Element" ],
       "meta": {
         "allowedIn": [
-          "bpmn:Task",
-          "bpmn:ServiceTask",
-          "bpmn:SendTask",
-          "bpmn:UserTask",
-          "bpmn:BusinessRuleTask",
-          "bpmn:ScriptTask",
-          "bpmn:ReceiveTask",
-          "bpmn:CallActivity",
-          "bpmn:TimerEventDefinition",
-          "bpmn:SignalEventDefinition",
-          "bpmn:MultiInstanceLoopCharacteristics",
-          "bpmn:SubProcess"
+          "camunda:AsyncCapable",
+          "bpmn:MultiInstanceLoopCharacteristics"
         ]
       },
       "properties": [

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -87,10 +87,27 @@ describe('extension', function() {
       expect(canCopyProperty).to.be.false;
     });
 
+
+    it('should allow if parent is ServiceTask', function() {
+
+      // given
+      var connector = moddle.create('camunda:Connector'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          serviceTask = moddle.create('bpmn:ServiceTask');
+
+      extensionElements.$parent = serviceTask;
+
+      // when
+      var canCopyProperty = camundaModdleExtension.canCopyProperty(connector, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
   });
 
 
-  describe('field', function() {
+  describe('camunda:Field', function() {
 
     it('should allow if parent has MessageEventDefinition', function() {
 
@@ -163,9 +180,9 @@ describe('extension', function() {
   });
 
 
-  describe('retry cycle', function() {
+  describe('camunda:FailedJobRetryTimeCycle', function() {
 
-    it('should allow if parent has SignalEventDefinition and is IntermediateThrowEvent',
+    it('should allow if parent is Signal IntermediateThrowEvent',
       function() {
 
         // given
@@ -190,7 +207,7 @@ describe('extension', function() {
     );
 
 
-    it('should NOT allow if parent has SignalEventDefinition and is not IntermediateThrowEvent',
+    it('should allow if parent is Signal StartEvent',
       function() {
 
         // given
@@ -210,12 +227,12 @@ describe('extension', function() {
         var canCopyProperty = camundaModdleExtension.canCopyProperty(retryCycle, extensionElements);
 
         // then
-        expect(canCopyProperty).to.be.false;
+        expect(canCopyProperty).not.to.be.false;
       }
     );
 
 
-    it('should allow if parent has TimerEventDefinition is catching', function() {
+    it('should allow if parent is Timer IntermediateCatchEvent', function() {
 
       // given
       var retryCycle = moddle.create('camunda:FailedJobRetryTimeCycle'),
@@ -238,7 +255,7 @@ describe('extension', function() {
     });
 
 
-    it('should NOT allow if parent has TimerEventDefinition and is not catching', function() {
+    it('should allow if parent is Timer EndEvent', function() {
 
       // given
       var retryCycle = moddle.create('camunda:FailedJobRetryTimeCycle'),
@@ -257,11 +274,11 @@ describe('extension', function() {
       var canCopyProperty = camundaModdleExtension.canCopyProperty(retryCycle, extensionElements);
 
       // then
-      expect(canCopyProperty).to.be.false;
+      expect(canCopyProperty).not.to.be.false;
     });
 
 
-    it('should NOT allow if parent has no SignalEventDefinition or TimerEventDefinition',
+    it('should allow if parent is Message IntermediateCatchEvent',
       function() {
 
         // given
@@ -281,12 +298,12 @@ describe('extension', function() {
         var canCopyProperty = camundaModdleExtension.canCopyProperty(retryCycle, extensionElements);
 
         // then
-        expect(canCopyProperty).to.be.false;
+        expect(canCopyProperty).not.to.be.false;
       }
     );
 
 
-    it('should allow if parent is loop characteristics', function() {
+    it('should allow if parent is MultiInstanceLoopCharacteristics', function() {
 
       // given
       var retryCycle = moddle.create('camunda:FailedJobRetryTimeCycle'),
@@ -307,7 +324,7 @@ describe('extension', function() {
   });
 
 
-  describe('task listener', function() {
+  describe('camunda:TaskListener', function() {
 
     it('should allow if parent is user task', function() {
 
@@ -348,7 +365,69 @@ describe('extension', function() {
 
   });
 
+
+  describe('camunda:InputOutput', function() {
+
+    it('should NOT allow on Gateway', function() {
+
+      // given
+      var inputOutput = moddle.create('camunda:InputOutput'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          gateway = moddle.create('bpmn:Gateway');
+
+      extensionElements.$parent = gateway;
+
+      gateway.extensionElements = extensionElements;
+
+      // when
+      var canCopyProperty = camundaModdleExtension.canCopyProperty(inputOutput, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+
+    it('should NOT allow on BoundaryEvent', function() {
+
+      // given
+      var inputOutput = moddle.create('camunda:InputOutput'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          boundaryEvent = moddle.create('bpmn:BoundaryEvent');
+
+      extensionElements.$parent = boundaryEvent;
+
+      boundaryEvent.extensionElements = extensionElements;
+
+      // when
+      var canCopyProperty = camundaModdleExtension.canCopyProperty(inputOutput, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+
+    it('should NOT allow on StartEvent', function() {
+
+      // given
+      var inputOutput = moddle.create('camunda:InputOutput'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          startEvent = moddle.create('bpmn:StartEvent');
+
+      extensionElements.$parent = startEvent;
+
+      startEvent.extensionElements = extensionElements;
+
+      // when
+      var canCopyProperty = camundaModdleExtension.canCopyProperty(inputOutput, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+  });
+
 });
+
 
 // helpers //////////
 


### PR DESCRIPTION
* camunda:InputOutput is not allowed in Gateway
* camunda:FailedJobRetryTimeCycle is allowed on all camunda:AsycnCapable
elements

Aligns input output rules with changes in https://github.com/bpmn-io/bpmn-js-properties-panel/pull/314/commits/cdbb1fc6d5c61d33c7c4ad788da792f2c058796f.

Simplifies `camunda:FailedJobRetryTimeCycle` to be properly copied everywhere (https://github.com/camunda/camunda-modeler/issues/1464).

Related to https://github.com/camunda/camunda-modeler/issues/1465