### PR TITLE
feat(camunda): extend schema for timeout task listener properties

### DIFF
--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -884,6 +884,16 @@
           "name": "fields",
           "type": "Field",
           "isMany": true
+        },
+        {
+          "name": "id",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "eventDefinitions",
+          "type": "bpmn:TimerEventDefinition",
+          "isMany": true
         }
       ]
     },

--- a/test/fixtures/xml/camunda-timeout-taskListener.part.bpmn
+++ b/test/fixtures/xml/camunda-timeout-taskListener.part.bpmn
@@ -1,0 +1,7 @@
+<camunda:taskListener xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  event='timeout'
+  id="timeout-friendly">
+    <bpmn:timerEventDefinition>
+      <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+    </bpmn:timerEventDefinition>
+</camunda:taskListener>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1107,24 +1107,56 @@ describe('read', function() {
     });
 
 
-    it('camunda:taskListener', function(done) {
+    describe('camunda:taskListener', function() {
 
-      // given
-      var xml = readFile('test/fixtures/xml/camunda-taskListener.part.bpmn');
+      it('create event', function(done) {
 
-      // when
-      moddle.fromXML(xml, 'camunda:TaskListener', function(err, taskListener) {
+        // given
+        var xml = readFile('test/fixtures/xml/camunda-taskListener.part.bpmn');
 
-        // then
-        expect(taskListener).to.jsonEqual({
-          $type: 'camunda:TaskListener',
-          event: 'create',
-          class: 'org.camunda.bpm.engine.test.bpmn.usertask.UserTaskTestCreateTaskListener',
-          delegateExpression: '${myTaskListener}',
-          expression: '${myTaskListener.notify(task, task.eventName)}'
+        // when
+        moddle.fromXML(xml, 'camunda:TaskListener', function(err, taskListener) {
+
+          // then
+          expect(taskListener).to.jsonEqual({
+            $type: 'camunda:TaskListener',
+            event: 'create',
+            class: 'org.camunda.bpm.engine.test.bpmn.usertask.UserTaskTestCreateTaskListener',
+            delegateExpression: '${myTaskListener}',
+            expression: '${myTaskListener.notify(task, task.eventName)}'
+          });
+
+          done(err);
         });
+      });
 
-        done(err);
+
+      it('timeout event', function(done) {
+
+        // given
+        var xml = readFile('test/fixtures/xml/camunda-timeout-taskListener.part.bpmn');
+
+        // when
+        moddle.fromXML(xml, 'camunda:TaskListener', function(err, taskListener) {
+
+          // then
+          expect(taskListener).to.jsonEqual({
+            $type: 'camunda:TaskListener',
+            event: 'timeout',
+            id: 'timeout-friendly',
+            eventDefinitions: [
+              {
+                $type: 'bpmn:TimerEventDefinition',
+                timeDuration: {
+                  $type: 'bpmn:FormalExpression',
+                  body: 'PT1H'
+                }
+              }
+            ]
+          });
+
+          done(err);
+        });
       });
     });
 


### PR DESCRIPTION
* `id` property for `camunda:TaskListener`
* `eventDefinitions` property for `camunda:TaskListener`

Related to camunda/camunda-modeler#1540