### PR TITLE
Rename existing event definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [camunda-bpmn-moddle](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `CHORE`: rename `*EventDefinition` to `*EventDefinitionExtension`
+
+### Breaking Changes
+
+* `*EventDefinition` elements were re-named by appending `Extension`. Adjust the name of these elements, if you extended or superclassed them. 
+
 ## 4.5.0
 
 * `FIX`: add `modelerTemplateVersion` property ([#60](https://github.com/camunda/camunda-bpmn-moddle/pull/60))

--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -135,7 +135,7 @@
       ]
     },
     {
-      "name": "SignalEventDefinition",
+      "name": "SignalEventDefinitionExtension",
       "isAbstract": true,
       "extends": [
         "bpmn:SignalEventDefinition"
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "name": "ErrorEventDefinition",
+      "name": "ErrorEventDefinitionExtension",
       "isAbstract": true,
       "extends": [
         "bpmn:ErrorEventDefinition"
@@ -301,7 +301,7 @@
       ]
     },
     {
-      "name": "EscalationEventDefinition",
+      "name": "EscalationEventDefinitionExtension",
       "isAbstract": true,
       "extends": [
         "bpmn:EscalationEventDefinition"
@@ -1064,7 +1064,7 @@
       ]
     },
     {
-      "name": "ConditionalEventDefinition",
+      "name": "ConditionalEventDefinitionExtension",
       "isAbstract": true,
       "extends": [
         "bpmn:ConditionalEventDefinition"


### PR DESCRIPTION
This PR renames existing event definition extensions to pave the way for the new `camunda:errorEventDefinition` element, that would otherwise conflict with the current version.

Tests are passing in both this repository and the `bpmn-js-properties-panel`.
An assumption is made that this renaming doesn't affect any existing implementation.

Related to https://github.com/camunda/camunda-modeler/issues/2070