### PR TITLE
Support ErrorEventDefinition for external ServiceTasks

### DIFF
--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -169,6 +169,22 @@
       ]
     },
     {
+      "name": "ErrorEventDefinition",
+      "superClass": [
+        "bpmn:ErrorEventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "expression",
+          "isAttr": true,
+          "type": "String"
+        }
+      ],
+      "meta": {
+        "allowedIn": [ "bpmn:ServiceTask" ]
+      }
+    },
+    {
       "name": "Error",
       "isAbstract": true,
       "extends": [

--- a/test/fixtures/xml/camunda-errorEventDefinition.part.bpmn
+++ b/test/fixtures/xml/camunda-errorEventDefinition.part.bpmn
@@ -1,0 +1,4 @@
+<camunda:errorEventDefinition xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  id="Id_1"
+  expression="${true}"/>

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -324,6 +324,48 @@ describe('extension', function() {
   });
 
 
+  describe('camunda:ErrorEventDefinition', function() {
+
+    it('should allow if parent is service task', function() {
+
+      // given
+      var errorEventDefinition = moddle.create('camunda:ErrorEventDefinition'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          serviceTask = moddle.create('bpmn:ServiceTask');
+
+      extensionElements.$parent = serviceTask;
+
+      serviceTask.extensionElements = extensionElements;
+
+      // when
+      var canCopyProperty = camundaModdleExtension.canCopyProperty(errorEventDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should not allow if parent is not a service task', function() {
+
+      // given
+      var errorEventDefinition = moddle.create('camunda:ErrorEventDefinition'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          userTask = moddle.create('bpmn:UserTask');
+
+      extensionElements.$parent = userTask;
+
+      userTask.extensionElements = extensionElements;
+
+      // when
+      var canCopyProperty = camundaModdleExtension.canCopyProperty(errorEventDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+  });
+
+
   describe('camunda:TaskListener', function() {
 
     it('should allow if parent is user task', function() {

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -143,6 +143,31 @@ describe('read', function() {
     });
 
 
+    describe('camunda:errorEventDefinition', function() {
+
+      it('attributes', function(done) {
+
+        // given
+        var xml = readFile('test/fixtures/xml/camunda-errorEventDefinition.part.bpmn');
+
+        // when
+        moddle.fromXML(xml, 'camunda:ErrorEventDefinition', function(err, errorEventDefinition) {
+
+          // then
+          expect(errorEventDefinition).to.jsonEqual({
+            $type: 'camunda:ErrorEventDefinition',
+            id: 'Id_1',
+            expression: '${true}'
+          });
+
+          done(err);
+        });
+
+      });
+
+    });
+
+
     describe('camunda:errorCodeVariable', function() {
 
       it('on ErrorEventDefinition', function(done) {


### PR DESCRIPTION
This PR adds the `camunda:ErrorEventDefinition` element to the moddle.

Related to https://github.com/camunda/camunda-modeler/issues/2070