### PR TITLE
Add Element type inheritance to camunda:ErrorEventDefinition

### DIFF
--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -171,7 +171,8 @@
     {
       "name": "ErrorEventDefinition",
       "superClass": [
-        "bpmn:ErrorEventDefinition"
+        "bpmn:ErrorEventDefinition",
+        "Element"
       ],
       "properties": [
         {

--- a/test/fixtures/xml/camunda-errorEventDefinition.part.bpmn
+++ b/test/fixtures/xml/camunda-errorEventDefinition.part.bpmn
@@ -1,4 +1,0 @@
-<camunda:errorEventDefinition xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
-  id="Id_1"
-  expression="${true}"/>

--- a/test/fixtures/xml/serviceTask-camunda-errorEventDefinition.part.bpmn
+++ b/test/fixtures/xml/serviceTask-camunda-errorEventDefinition.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:serviceTask>
+    <bpmn:extensionElements>
+        <camunda:errorEventDefinition xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+        xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+        id="Id_1"
+        expression="${true}"/>
+    </bpmn:extensionElements>
+</bpmn:serviceTask>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -145,20 +145,29 @@ describe('read', function() {
 
     describe('camunda:errorEventDefinition', function() {
 
-      it('attributes', function(done) {
+      it('on ServiceTask', function(done) {
 
         // given
-        var xml = readFile('test/fixtures/xml/camunda-errorEventDefinition.part.bpmn');
+        var xml = readFile('test/fixtures/xml/serviceTask-camunda-errorEventDefinition.part.bpmn');
 
         // when
-        moddle.fromXML(xml, 'camunda:ErrorEventDefinition', function(err, errorEventDefinition) {
+        moddle.fromXML(xml, 'bpmn:ServiceTask', function(err, serviceTask) {
 
           // then
-          expect(errorEventDefinition).to.jsonEqual({
-            $type: 'camunda:ErrorEventDefinition',
-            id: 'Id_1',
-            expression: '${true}'
-          });
+          expect(serviceTask).to.jsonEqual({
+            $type: 'bpmn:ServiceTask',
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'camunda:ErrorEventDefinition',
+                  id: 'Id_1',
+                  expression: '${true}'
+                },
+              ],
+            },
+          }
+          );
 
           done(err);
         });


### PR DESCRIPTION
This PR fixes the faulty moddle element declaration by making the new `camunda:ErrorEventDefinition` inherit from the `Element` type.

Related to camunda/camunda-modeler#2070