### PR TITLE
fix: do not copy non existing root elements

### DIFF
--- a/lib/CopyPasteRootElementBehavior.js
+++ b/lib/CopyPasteRootElementBehavior.js
@@ -72,7 +72,7 @@ function CopyPasteRootElementBehavior(
     context.addedRootElements = [];
 
     referencedRootElements.forEach(function(element) {
-      if (!hasRootElement(element)) {
+      if (element && !hasRootElement(element)) {
 
         // add root element
         collectionAdd(rootElements, element);
@@ -127,12 +127,18 @@ function CopyPasteRootElementBehavior(
     if (referencedRootElements && referencedRootElements.length) {
 
       referencedRootElements.forEach(function(element, index) {
+
+        if (!element) {
+          return;
+        }
+
         if (!hasRootElement(element)) {
           element = moddleCopy.copyElement(
             element,
             bpmnFactory.create(element.$type)
           );
         }
+
         setRootElement(businessObject, element, index);
       });
     }
@@ -141,7 +147,8 @@ function CopyPasteRootElementBehavior(
   });
 }
 
-// Helpers
+
+// helpers //////////////////////////
 
 function getReferencingElement(element) {
   if (is(element, 'bpmn:ServiceTask')) {

--- a/test/browser/CopyPasteRootElementBehaviorSpec.js
+++ b/test/browser/CopyPasteRootElementBehaviorSpec.js
@@ -296,6 +296,57 @@ describe('browser - CopyPasteRootElementBehavior', function() {
           referencedRootElements,
           pastedRootElements;
 
+
+      describe('with one missing bpmn:Error reference', function() {
+
+        it('should not create any additional bpmn:Error', inject(
+          function(elementRegistry, copyPaste, canvas) {
+
+            // given
+            copiedServiceTask = elementRegistry.get('ServiceTask_4');
+
+            copiedBusinessObject = getBusinessObject(copiedServiceTask);
+
+            // assume
+            expect(getRootElementsOfType('bpmn:Error')).to.have.length(3);
+
+            // when
+            copyPaste.copy(copiedServiceTask);
+
+            pastedServiceTask = copyPaste.paste({
+              element: canvas.getRootElement(),
+              point: {
+                x: copiedServiceTask.x,
+                y: copiedServiceTask.y
+              },
+            })[0];
+
+            pastedBusinessObject = getBusinessObject(pastedServiceTask);
+
+            var extensionElements = getErrorEventDefinitions(pastedBusinessObject);
+
+            pastedRootElements = extensionElements
+              .reduce(function(rootElements, extensionElement) {
+
+                if (extensionElement.errorRef) {
+                  rootElements.push(extensionElement.errorRef);
+                }
+
+                return rootElements;
+              }, []);
+
+            // then
+            expect(getRootElementsOfType('bpmn:Error')).to.have.length(3);
+
+            pastedRootElements.forEach(function(referencedRootElement) {
+              expect(hasRootElement(referencedRootElement)).to.be.true;
+            });
+          })
+        );
+
+      });
+
+
       describe('without altering any root bpmn:Error', function() {
 
         beforeEach(inject(function(bpmnjs, elementRegistry, copyPaste, modeling, canvas) {
@@ -503,7 +554,8 @@ describe('browser - CopyPasteRootElementBehavior', function() {
 
 });
 
-// helper ////
+
+// helper ///////////////////////
 
 function getErrorEventDefinitions(bo) {
   return getExtensionElementsOfType(bo, 'camunda:ErrorEventDefinition');

--- a/test/fixtures/xml/RootElementReferenceBehavior.bpmn
+++ b/test/fixtures/xml/RootElementReferenceBehavior.bpmn
@@ -14,6 +14,13 @@
         <camunda:errorEventDefinition id="ErrorEventDefinition_1svvscz" errorRef="Error_3" expression="Expression_3" />
       </bpmn:extensionElements>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_4" camunda:type="external" camunda:topic="topic">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1yppcqz" errorRef="Error_1" expression="Expression_1" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1i68vzs" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_0awnqeg" errorRef="Error_2" expression="Expression_2" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmn:error id="Error_1" name="Error_1" errorCode="Code_1" />
   <bpmn:error id="Error_2" name="Error_2" errorCode="Code_2" />
@@ -28,6 +35,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_04lse59_di" bpmnElement="ServiceTask_3">
         <dc:Bounds x="590" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0h45fbf_di" bpmnElement="ServiceTask_4">
+        <dc:Bounds x="260" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Prevent trying to copy non-existing root element references.

I would like to prevent [registering the undefined references](https://github.com/camunda/camunda-bpmn-moddle/blob/master/lib/CopyPasteRootElementBehavior.js#L109) on the copy-phase, but the way the pasting is currently implemented does not allow this.

Therefore let's make sure we do not try to paste non-existing element references at all.

Related to camunda/camunda-modeler#2196