### PR TITLE
Fix remove initiator behaviour

### DIFF
--- a/lib/RemoveInitiatorBehaviour.js
+++ b/lib/RemoveInitiatorBehaviour.js
@@ -18,13 +18,14 @@ function RemoveInitiatorBehaviour(
   this.postExecuted(['shape.create','shape.move'], function(context) {
 
     var shape = context.shape;
+    var newParent = context.newParent || context.parent;
     var businessObject = getBusinessObject(shape);
 
     // if shape is a startEvent and has an initiator proterty
     if (is(shape, 'bpmn:StartEvent') && businessObject.get('camunda:initiator')!=undefined) {
 
       // if subProcess becomes the new parent
-      if ((is(context.newParent, 'bpmn:SubProcess'))) {
+      if ((is(newParent, 'bpmn:SubProcess'))) {
 
         // remove initiator property
         modeling.updateProperties(shape, { 'camunda:initiator': undefined });

--- a/lib/RemoveInitiatorBehaviour.js
+++ b/lib/RemoveInitiatorBehaviour.js
@@ -7,7 +7,7 @@ var is = require('bpmn-js/lib/util/ModelUtil').is;
 var getBusinessObject = require('bpmn-js/lib/util/ModelUtil').getBusinessObject;
 
 /**
- * Remove 'camunda:initiator' property when a startEvent is moved to or created within a subProcess
+ * Remove `camunda:initiator` property when a startEvent is moved to or created within a subProcess.
  */
 function RemoveInitiatorBehaviour(
     modeling, injector
@@ -17,12 +17,12 @@ function RemoveInitiatorBehaviour(
 
   this.postExecuted(['shape.create','shape.move'], function(context) {
 
-    var shape = context.shape;
-    var newParent = context.newParent || context.parent;
-    var businessObject = getBusinessObject(shape);
+    var shape = context.shape,
+        newParent = context.newParent || context.parent,
+        businessObject = getBusinessObject(shape);
 
     // if shape is a startEvent and has an initiator proterty
-    if (is(shape, 'bpmn:StartEvent') && businessObject.get('camunda:initiator')!=undefined) {
+    if (is(shape, 'bpmn:StartEvent') && businessObject.get('camunda:initiator') !== undefined) {
 
       // if subProcess becomes the new parent
       if ((is(newParent, 'bpmn:SubProcess'))) {

--- a/test/browser/RemoveInitiatorBehaviorSpec.js
+++ b/test/browser/RemoveInitiatorBehaviorSpec.js
@@ -52,13 +52,12 @@ describe('browser - RemoveInitiatorBehaviour', function() {
         expect(startBusinessObject.get('camunda:initiator')).to.not.be.undefined;
 
         // when
-        modeling.moveShape(startEvent, { x: (subProcess.x+subProcess.width/4), y: (subProcess.y+subProcess.height/4) }, subProcess);
+        modeling.moveShape(startEvent, { x: (subProcess.x + subProcess.width / 4), y: (subProcess.y + subProcess.height / 4) }, subProcess);
 
         // then
         expect(startBusinessObject.get('camunda:initiator')).to.be.undefined;
 
-      }
-      ));
+      }));
 
     });
 
@@ -80,10 +79,10 @@ describe('browser - RemoveInitiatorBehaviour', function() {
         // then
         expect(startBusinessObject.get('camunda:initiator')).to.be.undefined;
 
-      }
-      ));
+      }));
 
     });
+
 
     describe('when event with property and subprocess as parent is moved', function() {
 
@@ -102,13 +101,12 @@ describe('browser - RemoveInitiatorBehaviour', function() {
         expect(startBusinessObject.get('camunda:initiator')).to.not.be.undefined;
 
         // when
-        modeling.moveShape(startEvent, { x: (subProcess.x+subProcess.width/4), y: (subProcess.y+subProcess.height/4) });
+        modeling.moveShape(startEvent, { x: (subProcess.x + subProcess.width / 4), y: (subProcess.y + subProcess.height / 4) });
 
         // then
         expect(startBusinessObject.get('camunda:initiator')).to.be.undefined;
 
-      }
-      ));
+      }));
 
     });
 

--- a/test/browser/RemoveInitiatorBehaviorSpec.js
+++ b/test/browser/RemoveInitiatorBehaviorSpec.js
@@ -65,18 +65,17 @@ describe('browser - RemoveInitiatorBehaviour', function() {
 
     describe('when event is created within a subprocess', function() {
 
-      var startEvent,
-          startBusinessObject,
+      var startBusinessObject,
           subProcess;
 
-      it('should not have an initiator property', inject(function(elementRegistry, modeling, elementFactory, canvas, copyPaste) {
+      it('should not have an initiator property', inject(function(elementRegistry, modeling, bpmnFactory) {
 
         // given
         subProcess = elementRegistry.get('Activity_subprocess1');
+        startBusinessObject = bpmnFactory.create('bpmn:StartEvent', { initiator:'abc' });
 
         // when
-        startEvent = modeling.createShape({ type: 'bpmn:StartEvent', 'camunda:initiator': 'abc' }, { x: 0, y: 0 }, subProcess);
-        startBusinessObject = getBusinessObject(startEvent);
+        modeling.createShape({ type: 'bpmn:StartEvent', businessObject:startBusinessObject }, { x: 0, y: 0 }, subProcess);
 
         // then
         expect(startBusinessObject.get('camunda:initiator')).to.be.undefined;


### PR DESCRIPTION
Related to #74 old PR merged https://github.com/camunda/camunda-bpmn-moddle/pull/75

There was a mistake in how one of the test cases was being done and in one of the check conditions to remove the `initiator` property