### PR TITLE
fix: remove `camunda:formRefBinding` default value

### DIFF
--- a/resources/camunda.json
+++ b/resources/camunda.json
@@ -237,8 +237,7 @@
         {
           "name": "formRefBinding",
           "isAttr": true,
-          "type": "String",
-          "default": "latest"
+          "type": "String"
         },
         {
           "name": "formRefVersion",

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -76,6 +76,26 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
+    it('UserTask#formRefBinding', async function() {
+
+      // given
+      var element = moddle.create('bpmn:UserTask', {
+        'camunda:formRefBinding': 'latest'
+      });
+
+      var expectedXML =
+        '<bpmn:userTask xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+                       'xmlns:camunda="http://camunda.org/schema/1.0/bpmn" ' +
+                       'camunda:formRefBinding="latest" />';
+
+      // when
+      var { xml } = await write(element);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
There is no default for that.

Related to https://github.com/camunda/camunda-modeler/issues/2484