### PR TITLE
chore: simplify root element copy behavior

### DIFF
--- a/lib/CopyPasteRootElementBehavior.js
+++ b/lib/CopyPasteRootElementBehavior.js
@@ -88,7 +88,7 @@ export default function CopyPasteRootElementBehavior(
         element = context.element,
         businessObject = getBusinessObject(element);
 
-    if (!canHaveNestedRootElementReference(businessObject)) {
+    if (element.labelTarget || !canHaveNestedRootElementReference(businessObject)) {
       return;
     }
 
@@ -99,38 +99,33 @@ export default function CopyPasteRootElementBehavior(
     }
   });
 
-
   eventBus.on('copyPaste.pasteElement', LOW_PRIORITY, function(context) {
     var descriptor = context.descriptor,
-        businessObject = descriptor.businessObject;
+        businessObject = descriptor.businessObject,
+        referencedRootElements = descriptor.referencedRootElements;
 
-    if (!canHaveNestedRootElementReference(businessObject)) {
+    if (!referencedRootElements) {
       return;
     }
 
-    var referencedRootElements = descriptor.referencedRootElements;
+    referencedRootElements.forEach(function(reference) {
 
-    if (referencedRootElements && referencedRootElements.length) {
+      var element = reference.referencedElement,
+          idx = reference.idx;
 
-      referencedRootElements.forEach(function(reference) {
+      if (!element) {
+        return;
+      }
 
-        var element = reference.referencedElement,
-            idx = reference.idx;
+      if (!hasRootElement(element)) {
+        element = moddleCopy.copyElement(
+          element,
+          bpmnFactory.create(element.$type)
+        );
+      }
 
-        if (!element) {
-          return;
-        }
-
-        if (!hasRootElement(element)) {
-          element = moddleCopy.copyElement(
-            element,
-            bpmnFactory.create(element.$type)
-          );
-        }
-
-        setRootElement(businessObject, element, idx);
-      });
-    }
+      setRootElement(businessObject, element, idx);
+    });
 
     delete descriptor.referencedRootElements;
   });
@@ -194,7 +189,7 @@ function getRootElements(bo, extensionElementType) {
     });
   }
 
-  var rootElements = filteredExtensionElements.reduce(function(result, element) {
+  return filteredExtensionElements.reduce(function(result, element) {
 
     rootElementReference = element[getRootElementReferencePropertyName(element)];
 
@@ -207,8 +202,6 @@ function getRootElements(bo, extensionElementType) {
 
     return result;
   }, []);
-
-  return rootElements;
 }
 
 function setRootElement(bo, rootElement, index) {


### PR DESCRIPTION
Follows along changes performed in https://github.com/bpmn-io/bpmn-js/pull/1707:

* simplify root element copy behavior
* do not execute copy logic on labels